### PR TITLE
KAN-12-feat: NestingAvatar 컴포넌트 구현

### DIFF
--- a/components/NestingAvatar.tsx
+++ b/components/NestingAvatar.tsx
@@ -1,0 +1,44 @@
+import { Avatar } from '@radix-ui/themes'
+
+interface INestingAvatarProps {
+  config: { imageUrl: string; fallback: string }[]
+  displayLimit: number
+}
+
+function NestingAvatar({ config, displayLimit }: INestingAvatarProps) {
+  const sliceConfig = config
+    .map((item) => ({
+      imageUrl: item.imageUrl,
+      fallback: item.fallback.slice(0, 1),
+    }))
+    .slice(0, displayLimit)
+
+  return (
+    <div className="flex items-center justify-center">
+      {sliceConfig.map((item, index) => (
+        <Avatar
+          style={{
+            transform: `translateX(${index !== 0 ? `${-10 * index}px` : '0'})`,
+          }}
+          className="h-29pxr w-29pxr rounded-full"
+          color="gray"
+          key={item.imageUrl}
+          src={item.imageUrl}
+          fallback={
+            <div className="h-29pxr w-29pxr content-center rounded-full bg-[#D9D9D9] text-center text-14pxr font-medium text-black">
+              {item.fallback}
+            </div>
+          }
+        />
+      ))}
+      <div
+        style={{ transform: `translateX(${displayLimit * -10}px)` }}
+        className="h-29pxr w-29pxr content-center rounded-full bg-[#D9D9D9] text-center text-14pxr font-medium text-black"
+      >
+        +{config.length - displayLimit}
+      </div>
+    </div>
+  )
+}
+
+export default NestingAvatar


### PR DESCRIPTION
## 구현 사항

- NestingAvatar 컴포넌트 구현

## 설명

- displayLimit는 이미지가 표시될 개수 입니다. 아래 이미지 참고 부탁드립니다.

## 관련 이미지 (선택)
![image](https://github.com/4team-codeIt/Front/assets/79037820/010607d9-b685-4626-9545-ad30a607a912)

## Jira
https://jkdk981024.atlassian.net/browse/KAN-12?atlOrigin=eyJpIjoiNDM2N2NhOGNkZWQ0NDI2ZGI3NWU2ZTlmNDNmMGQ1YWQiLCJwIjoiaiJ9