### PR TITLE
KAN-11-feat : PeopleCounter (인원수프로그레스바)초안, Radix UI Progress install

### DIFF
--- a/components/AnimatedProgress.tsx
+++ b/components/AnimatedProgress.tsx
@@ -8,17 +8,14 @@ interface AnimatedProgressProps {
 }
 function AnimatedProgress({ current, max, min }: AnimatedProgressProps) {
   const [progress, setProgress] = React.useState(0)
-  const [bg, setBg] = React.useState('')
+  const ProgressbarColor = current > min ? 'bg-green-600' : 'bg-slate-400'
 
   React.useEffect(() => {
-    const ProgressbarColor = current > min ? 'bg-green-600' : 'bg-slate-400'
-    setBg(ProgressbarColor)
-
     const value = (current / max) * 100
     const timer = setTimeout(() => setProgress(value), 500)
 
     return () => clearTimeout(timer)
-  }, [current, max, min])
+  }, [current, max])
 
   return (
     <Progress.Root
@@ -29,7 +26,7 @@ function AnimatedProgress({ current, max, min }: AnimatedProgressProps) {
       value={progress}
     >
       <Progress.Indicator
-        className={`${bg} ease-[cubic-bezier(0.65, 0, 0.35, 1)] h-full w-full transition-transform duration-[660ms]`}
+        className={`${ProgressbarColor} ease-[cubic-bezier(0.65, 0, 0.35, 1)] h-full w-full transition-transform duration-[660ms]`}
         style={{ transform: `translateX(-${100 - progress}%)` }}
       />
     </Progress.Root>

--- a/components/AnimatedProgress.tsx
+++ b/components/AnimatedProgress.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import * as Progress from '@radix-ui/react-progress'
+
+interface AnimatedProgressProps {
+  max: number
+  min: number
+  current: number
+}
+function AnimatedProgress({ current, max, min }: AnimatedProgressProps) {
+  const [progress, setProgress] = React.useState(0)
+  const [bg, setBg] = React.useState('')
+
+  React.useEffect(() => {
+    const ProgressbarColor = current > min ? 'bg-green-600' : 'bg-slate-400'
+    setBg(ProgressbarColor)
+
+    const value = (current / max) * 100
+    const timer = setTimeout(() => setProgress(value), 500)
+
+    return () => clearTimeout(timer)
+  }, [current, max, min])
+
+  return (
+    <Progress.Root
+      className="relative h-15pxr w-full overflow-hidden bg-slate-100"
+      style={{
+        transform: 'translateZ(0)',
+      }}
+      value={progress}
+    >
+      <Progress.Indicator
+        className={`${bg} ease-[cubic-bezier(0.65, 0, 0.35, 1)] h-full w-full transition-transform duration-[660ms]`}
+        style={{ transform: `translateX(-${100 - progress}%)` }}
+      />
+    </Progress.Root>
+  )
+}
+
+export default AnimatedProgress

--- a/components/AnimatedProgress.tsx
+++ b/components/AnimatedProgress.tsx
@@ -8,7 +8,7 @@ interface AnimatedProgressProps {
 }
 function AnimatedProgress({ current, max, min }: AnimatedProgressProps) {
   const [progress, setProgress] = React.useState(0)
-  const ProgressbarColor = current > min ? 'bg-green-600' : 'bg-slate-400'
+  const progressbarColor = current > min ? 'bg-green-600' : 'bg-slate-400'
 
   React.useEffect(() => {
     const value = (current / max) * 100
@@ -26,7 +26,7 @@ function AnimatedProgress({ current, max, min }: AnimatedProgressProps) {
       value={progress}
     >
       <Progress.Indicator
-        className={`${ProgressbarColor} ease-[cubic-bezier(0.65, 0, 0.35, 1)] h-full w-full transition-transform duration-[660ms]`}
+        className={`${progressbarColor} ease-[cubic-bezier(0.65, 0, 0.35, 1)] h-full w-full transition-transform duration-[660ms]`}
         style={{ transform: `translateX(-${100 - progress}%)` }}
       />
     </Progress.Root>

--- a/components/PeopleCounter.tsx
+++ b/components/PeopleCounter.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import AnimatedProgress from './AnimatedProgress'
+
+interface PeopleCounterProps {
+  current: number
+  min: number
+  max: number
+}
+function PeopleCounter({ current, min, max }: PeopleCounterProps) {
+  const minPersent = (min / max) * 100
+
+  return (
+    <div className="flex h-fit justify-center">
+      <div className="flex w-200pxr flex-col gap-2pxr">
+        <div className="relative">
+          <AnimatedProgress min={min} current={current} max={max} />
+          <div className="h-10pxr w-full border-x-[2px]">
+            <div
+              className="absolute h-10pxr -translate-x-1/2 border-x-[1px]"
+              style={{ left: `${minPersent}%` }}
+            />
+          </div>
+          <p className="font-6pxr absolute -translate-x-1/2 transform">0</p>
+          <p
+            className="font-6pxr absolute -translate-x-1/2"
+            style={{ left: `${minPersent}%` }}
+          >
+            {min}
+          </p>
+          <p className="font-6pxr absolute right-0pxr translate-x-1/2 transform">
+            {max}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PeopleCounter

--- a/components/PeopleCounter.tsx
+++ b/components/PeopleCounter.tsx
@@ -8,23 +8,28 @@ interface PeopleCounterProps {
   max: number
 }
 function PeopleCounter({ current, min, max }: PeopleCounterProps) {
-  const minPersent = (min / max) * 100
+  const minPercent = (min / max) * 100
 
   return (
     <div className="flex h-fit justify-center">
       <div className="flex w-200pxr flex-col gap-2pxr">
         <div className="relative">
-          <AnimatedProgress min={min} current={current} max={max} />
+          <AnimatedProgress
+            min={min}
+            current={current}
+            max={max}
+            key="프로그레스바"
+          />
           <div className="h-10pxr w-full border-x-[2px]">
             <div
               className="absolute h-10pxr -translate-x-1/2 border-x-[1px]"
-              style={{ left: `${minPersent}%` }}
+              style={{ left: `${minPercent}%` }}
             />
           </div>
           <p className="font-6pxr absolute -translate-x-1/2 transform">0</p>
           <p
             className="font-6pxr absolute -translate-x-1/2"
-            style={{ left: `${minPersent}%` }}
+            style={{ left: `${minPercent}%` }}
           >
             {min}
           </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dalem",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/themes": "^3.1.1",
         "@tanstack/react-query": "^5.48.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cy:open": "cypress open"
   },
   "dependencies": {
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/themes": "^3.1.1",
     "@tanstack/react-query": "^5.48.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## 구현 사항

- 인원수에 따른 모집인원 진행도를 나타내는 PeopleCounter 초안


## 설명

- AnimatedProgress 가 아니라 PeopleCounter로 불러와서써야합니다

- current, max, min  으로 각각 현제인원, 최대인원, 최소충족인원으로 값 입력해서 쓰시면 됩니다

## 관련 이미지 (선택)

![image](https://github.com/4team-codeIt/Front/assets/148180423/3c900523-2ed4-46fc-b084-d0ad6b310c5e)


![image](https://github.com/4team-codeIt/Front/assets/148180423/3eaf8829-0e0e-40ed-9b9e-637bb9b286d0)

## Jira

[KAN-11](https://jkdk981024.atlassian.net/browse/KAN-11)


[KAN-11]: https://jkdk981024.atlassian.net/browse/KAN-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ